### PR TITLE
Add configurable sync options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# PlayerDataSync
+
+A simple Bukkit/Spigot plugin for Minecraft 1.21+ that synchronizes player data using either a MySQL or SQLite database. This project is built with Maven.
+
+## Building
+
+Run the following command in the project directory:
+
+```bash
+mvn package
+```
+
+The resulting jar can be found in `target/`.
+
+## Configuration
+
+`config.yml` contains the database connection settings and options to control which
+player data should be synchronized:
+
+```yaml
+database:
+  type: mysql # or sqlite
+  mysql:
+    host: localhost
+    port: 3306
+    database: minecraft
+    user: root
+    password: password
+  sqlite:
+    file: plugins/PlayerDataSync/playerdata.db
+
+sync:
+  coordinates: true
+  xp: true
+  gamemode: true
+  enderchest: true
+  inventory: true
+  health: true
+  hunger: true
+  position: true
+```
+
+Update the database values to match your environment. Set any of the `sync` options to
+`false` if you want to skip syncing that particular data type.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>PlayerDataSync</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <minecraft.version>1.21.7</minecraft.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${minecraft.version}-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.32</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.42.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -1,0 +1,108 @@
+package com.example.playerdatasync;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class PlayerDataSync extends JavaPlugin {
+    private Connection connection;
+    private String databaseType;
+    private boolean syncCoordinates;
+    private boolean syncXp;
+    private boolean syncGamemode;
+    private boolean syncEnderchest;
+    private boolean syncInventory;
+    private boolean syncHealth;
+    private boolean syncHunger;
+    private boolean syncPosition;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        databaseType = getConfig().getString("database.type", "mysql");
+        try {
+            if (databaseType.equalsIgnoreCase("mysql")) {
+                String host = getConfig().getString("database.mysql.host", "localhost");
+                int port = getConfig().getInt("database.mysql.port", 3306);
+                String database = getConfig().getString("database.mysql.database", "minecraft");
+                String user = getConfig().getString("database.mysql.user", "root");
+                String password = getConfig().getString("database.mysql.password", "");
+                String url = String.format("jdbc:mysql://%s:%d/%s", host, port, database);
+                connection = DriverManager.getConnection(url, user, password);
+                getLogger().info("Connected to MySQL database");
+            } else {
+                String file = getConfig().getString("database.sqlite.file", "plugins/PlayerDataSync/playerdata.db");
+                String url = "jdbc:sqlite:" + file;
+                connection = DriverManager.getConnection(url);
+                getLogger().info("Connected to SQLite database");
+            }
+        } catch (SQLException e) {
+            getLogger().severe("Could not connect to database: " + e.getMessage());
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        syncCoordinates = getConfig().getBoolean("sync.coordinates", true);
+        syncXp = getConfig().getBoolean("sync.xp", true);
+        syncGamemode = getConfig().getBoolean("sync.gamemode", true);
+        syncEnderchest = getConfig().getBoolean("sync.enderchest", true);
+        syncInventory = getConfig().getBoolean("sync.inventory", true);
+        syncHealth = getConfig().getBoolean("sync.health", true);
+        syncHunger = getConfig().getBoolean("sync.hunger", true);
+        syncPosition = getConfig().getBoolean("sync.position", true);
+    }
+
+    @Override
+    public void onDisable() {
+        if (connection != null) {
+            try {
+                connection.close();
+                if (databaseType.equalsIgnoreCase("mysql")) {
+                    getLogger().info("MySQL connection closed");
+                } else {
+                    getLogger().info("SQLite connection closed");
+                }
+            } catch (SQLException e) {
+                getLogger().severe("Error closing database connection: " + e.getMessage());
+            }
+        }
+    }
+
+    public Connection getConnection() {
+        return connection;
+    }
+
+    public boolean isSyncCoordinates() {
+        return syncCoordinates;
+    }
+
+    public boolean isSyncXp() {
+        return syncXp;
+    }
+
+    public boolean isSyncGamemode() {
+        return syncGamemode;
+    }
+
+    public boolean isSyncEnderchest() {
+        return syncEnderchest;
+    }
+
+    public boolean isSyncInventory() {
+        return syncInventory;
+    }
+
+    public boolean isSyncHealth() {
+        return syncHealth;
+    }
+
+    public boolean isSyncHunger() {
+        return syncHunger;
+    }
+
+    public boolean isSyncPosition() {
+        return syncPosition;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,20 @@
+database:
+  type: mysql # or sqlite
+  mysql:
+    host: localhost
+    port: 3306
+    database: minecraft
+    user: root
+    password: password
+  sqlite:
+    file: plugins/PlayerDataSync/playerdata.db
+
+sync:
+  coordinates: true
+  xp: true
+  gamemode: true
+  enderchest: true
+  inventory: true
+  health: true
+  hunger: true
+  position: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,5 @@
+name: PlayerDataSync
+main: com.example.playerdatasync.PlayerDataSync
+version: 1.0
+api-version: "1.21"
+author: DerGamer09


### PR DESCRIPTION
## Summary
- extend config with boolean options for syncing various player data
- load those options in `PlayerDataSync` with getters
- document new options in README
- support MySQL or SQLite via config and add sqlite dependency
- update plugin author

## Testing
- `mvn -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686808ce3e98832ebc61cd514e25b728