### PR TITLE
Fix missing ItemStack import

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -5,6 +5,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.sql.*;
 


### PR DESCRIPTION
## Summary
- fix missing `ItemStack` import in `DatabaseManager`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682aa23034832ea8371199a4ccd267