### PR TITLE
Add configurable sync command

### DIFF
--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -7,6 +7,7 @@ import org.bukkit.scheduler.BukkitTask;
 
 import com.example.playerdatasync.DatabaseManager;
 import com.example.playerdatasync.PlayerDataListener;
+import com.example.playerdatasync.SyncCommand;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -77,6 +78,9 @@ public class PlayerDataSync extends JavaPlugin {
         databaseManager = new DatabaseManager(this);
         databaseManager.initialize();
         getServer().getPluginManager().registerEvents(new PlayerDataListener(this, databaseManager), this);
+        if (getCommand("sync") != null) {
+            getCommand("sync").setExecutor(new SyncCommand(this));
+        }
     }
 
     @Override
@@ -137,5 +141,53 @@ public class PlayerDataSync extends JavaPlugin {
 
     public boolean isSyncPosition() {
         return syncPosition;
+    }
+
+    public void setSyncCoordinates(boolean value) {
+        this.syncCoordinates = value;
+        getConfig().set("sync.coordinates", value);
+        saveConfig();
+    }
+
+    public void setSyncXp(boolean value) {
+        this.syncXp = value;
+        getConfig().set("sync.xp", value);
+        saveConfig();
+    }
+
+    public void setSyncGamemode(boolean value) {
+        this.syncGamemode = value;
+        getConfig().set("sync.gamemode", value);
+        saveConfig();
+    }
+
+    public void setSyncEnderchest(boolean value) {
+        this.syncEnderchest = value;
+        getConfig().set("sync.enderchest", value);
+        saveConfig();
+    }
+
+    public void setSyncInventory(boolean value) {
+        this.syncInventory = value;
+        getConfig().set("sync.inventory", value);
+        saveConfig();
+    }
+
+    public void setSyncHealth(boolean value) {
+        this.syncHealth = value;
+        getConfig().set("sync.health", value);
+        saveConfig();
+    }
+
+    public void setSyncHunger(boolean value) {
+        this.syncHunger = value;
+        getConfig().set("sync.hunger", value);
+        saveConfig();
+    }
+
+    public void setSyncPosition(boolean value) {
+        this.syncPosition = value;
+        getConfig().set("sync.position", value);
+        saveConfig();
     }
 }

--- a/src/main/java/com/example/playerdatasync/SyncCommand.java
+++ b/src/main/java/com/example/playerdatasync/SyncCommand.java
@@ -1,0 +1,80 @@
+package com.example.playerdatasync;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class SyncCommand implements CommandExecutor {
+    private final PlayerDataSync plugin;
+
+    public SyncCommand(PlayerDataSync plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("Current sync settings:");
+            sender.sendMessage("coordinates: " + plugin.isSyncCoordinates());
+            sender.sendMessage("xp: " + plugin.isSyncXp());
+            sender.sendMessage("gamemode: " + plugin.isSyncGamemode());
+            sender.sendMessage("enderchest: " + plugin.isSyncEnderchest());
+            sender.sendMessage("inventory: " + plugin.isSyncInventory());
+            sender.sendMessage("health: " + plugin.isSyncHealth());
+            sender.sendMessage("hunger: " + plugin.isSyncHunger());
+            sender.sendMessage("position: " + plugin.isSyncPosition());
+            return true;
+        }
+
+        if (args.length == 2) {
+            String option = args[0].toLowerCase();
+            String val = args[1].toLowerCase();
+            if (!val.equals("true") && !val.equals("false")) {
+                sender.sendMessage("Usage: /sync <option> <true|false>");
+                return true;
+            }
+            boolean enabled = Boolean.parseBoolean(val);
+            if (option.equals("coordinates")) {
+                if (!hasPerm(sender, "coordinates")) return true;
+                plugin.setSyncCoordinates(enabled);
+            } else if (option.equals("xp")) {
+                if (!hasPerm(sender, "xp")) return true;
+                plugin.setSyncXp(enabled);
+            } else if (option.equals("gamemode")) {
+                if (!hasPerm(sender, "gamemode")) return true;
+                plugin.setSyncGamemode(enabled);
+            } else if (option.equals("enderchest")) {
+                if (!hasPerm(sender, "enderchest")) return true;
+                plugin.setSyncEnderchest(enabled);
+            } else if (option.equals("inventory")) {
+                if (!hasPerm(sender, "inventory")) return true;
+                plugin.setSyncInventory(enabled);
+            } else if (option.equals("health")) {
+                if (!hasPerm(sender, "health")) return true;
+                plugin.setSyncHealth(enabled);
+            } else if (option.equals("hunger")) {
+                if (!hasPerm(sender, "hunger")) return true;
+                plugin.setSyncHunger(enabled);
+            } else if (option.equals("position")) {
+                if (!hasPerm(sender, "position")) return true;
+                plugin.setSyncPosition(enabled);
+            } else {
+                sender.sendMessage("Unknown option: " + option);
+                return true;
+            }
+            sender.sendMessage("Set " + option + " sync to " + enabled);
+            return true;
+        }
+
+        sender.sendMessage("Usage: /sync [<option> <true|false>]");
+        return true;
+    }
+
+    private boolean hasPerm(CommandSender sender, String option) {
+        if (sender.hasPermission("playerdatasync.admin.*") || sender.hasPermission("playerdatasync.admin." + option)) {
+            return true;
+        }
+        sender.sendMessage("You do not have permission to change " + option);
+        return false;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,28 @@ main: com.example.playerdatasync.PlayerDataSync
 version: 1.0
 api-version: "1.21"
 author: DerGamer09
+commands:
+  sync:
+    description: View or change sync options
+    usage: /<command> [<option> <true|false>]
+    permission: playerdatasync.admin
+permissions:
+  playerdatasync.admin.*:
+    description: Allows all PlayerDataSync admin commands
+    default: op
+  playerdatasync.admin.coordinates:
+    default: op
+  playerdatasync.admin.xp:
+    default: op
+  playerdatasync.admin.gamemode:
+    default: op
+  playerdatasync.admin.enderchest:
+    default: op
+  playerdatasync.admin.inventory:
+    default: op
+  playerdatasync.admin.health:
+    default: op
+  playerdatasync.admin.hunger:
+    default: op
+  playerdatasync.admin.position:
+    default: op


### PR DESCRIPTION
## Summary
- add `SyncCommand` to view or change each sync option
- register command executor in `onEnable`
- expose setters for sync booleans and persist them to config
- define `/sync` command and permission nodes in `plugin.yml`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686833055c44832eae4cd8f53ff19e4a