### PR TITLE
Add multilingual messages

### DIFF
--- a/src/main/java/com/example/playerdatasync/MessageManager.java
+++ b/src/main/java/com/example/playerdatasync/MessageManager.java
@@ -1,0 +1,26 @@
+package com.example.playerdatasync;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+
+public class MessageManager {
+    private final PlayerDataSync plugin;
+    private FileConfiguration messages;
+
+    public MessageManager(PlayerDataSync plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load(String language) {
+        plugin.saveResource("messages_" + language + ".yml", false);
+        File file = new File(plugin.getDataFolder(), "messages_" + language + ".yml");
+        this.messages = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public String get(String key) {
+        if (messages == null) return key;
+        return messages.getString(key, key);
+    }
+}

--- a/src/main/java/com/example/playerdatasync/PlayerDataListener.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataListener.java
@@ -19,12 +19,14 @@ public class PlayerDataListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
+        player.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("loading"));
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> dbManager.loadPlayer(player));
     }
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
         Player player = event.getPlayer();
+        player.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("saving"));
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> dbManager.savePlayer(player));
     }
 }

--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
+import com.example.playerdatasync.MessageManager;
 
 import com.example.playerdatasync.DatabaseManager;
 import com.example.playerdatasync.PlayerDataListener;
@@ -28,10 +29,14 @@ public class PlayerDataSync extends JavaPlugin {
     private DatabaseManager databaseManager;
     private int autosaveInterval;
     private BukkitTask autosaveTask;
+    private MessageManager messageManager;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        messageManager = new MessageManager(this);
+        String lang = getConfig().getString("language", "en");
+        messageManager.load(lang);
         databaseType = getConfig().getString("database.type", "mysql");
         try {
             if (databaseType.equalsIgnoreCase("mysql")) {
@@ -109,6 +114,10 @@ public class PlayerDataSync extends JavaPlugin {
 
     public Connection getConnection() {
         return connection;
+    }
+
+    public MessageManager getMessageManager() {
+        return messageManager;
     }
 
     public boolean isSyncCoordinates() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,3 +21,5 @@ sync:
 
 autosave:
   interval: 5 # minutes between automatic saves, 0 to disable
+
+language: en

--- a/src/main/resources/messages_de.yml
+++ b/src/main/resources/messages_de.yml
@@ -1,0 +1,3 @@
+prefix: "[PDS]"
+loading: "Daten werden synchronisiert..."
+saving: "Spielerdaten werden gespeichert..."

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -1,0 +1,3 @@
+prefix: "[PDS]"
+loading: "Data is being synchronized..."
+saving: "Saving player data..."


### PR DESCRIPTION
## Summary
- add message manager for loading localized text
- show data sync messages on join/quit
- support English and German via new message files
- load language setting from config

## Testing
- `mvn package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686836ddb750832e81d9243a0bea1ace