### PR TITLE
Add reload command

### DIFF
--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -199,4 +199,38 @@ public class PlayerDataSync extends JavaPlugin {
         getConfig().set("sync.position", value);
         saveConfig();
     }
+
+    public void reloadPlugin() {
+        reloadConfig();
+
+        String lang = getConfig().getString("language", "en");
+        messageManager.load(lang);
+
+        syncCoordinates = getConfig().getBoolean("sync.coordinates", true);
+        syncXp = getConfig().getBoolean("sync.xp", true);
+        syncGamemode = getConfig().getBoolean("sync.gamemode", true);
+        syncEnderchest = getConfig().getBoolean("sync.enderchest", true);
+        syncInventory = getConfig().getBoolean("sync.inventory", true);
+        syncHealth = getConfig().getBoolean("sync.health", true);
+        syncHunger = getConfig().getBoolean("sync.hunger", true);
+        syncPosition = getConfig().getBoolean("sync.position", true);
+
+        int newInterval = getConfig().getInt("autosave.interval", 5);
+        if (newInterval != autosaveInterval) {
+            autosaveInterval = newInterval;
+            if (autosaveTask != null) {
+                autosaveTask.cancel();
+            }
+            if (autosaveInterval > 0) {
+                long ticks = autosaveInterval * 1200L;
+                autosaveTask = Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> {
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        databaseManager.savePlayer(player);
+                    }
+                }, ticks, ticks);
+            } else {
+                autosaveTask = null;
+            }
+        }
+    }
 }

--- a/src/main/java/com/example/playerdatasync/SyncCommand.java
+++ b/src/main/java/com/example/playerdatasync/SyncCommand.java
@@ -26,6 +26,13 @@ public class SyncCommand implements CommandExecutor {
             return true;
         }
 
+        if (args.length == 1 && args[0].equalsIgnoreCase("reload")) {
+            if (!hasPerm(sender, "reload")) return true;
+            plugin.reloadPlugin();
+            sender.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("reloaded"));
+            return true;
+        }
+
         if (args.length == 2) {
             String option = args[0].toLowerCase();
             String val = args[1].toLowerCase();

--- a/src/main/resources/messages_de.yml
+++ b/src/main/resources/messages_de.yml
@@ -1,3 +1,4 @@
 prefix: "[PDS]"
 loading: "Daten werden synchronisiert..."
 saving: "Spielerdaten werden gespeichert..."
+reloaded: "Konfiguration neu geladen"

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -1,3 +1,4 @@
 prefix: "[PDS]"
 loading: "Data is being synchronized..."
 saving: "Saving player data..."
+reloaded: "Configuration reloaded"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,3 +28,5 @@ permissions:
     default: op
   playerdatasync.admin.position:
     default: op
+  playerdatasync.admin.reload:
+    default: op


### PR DESCRIPTION
## Summary
- implement `reloadPlugin` in `PlayerDataSync`
- add `/sync reload` subcommand
- add permission `playerdatasync.admin.reload`
- include `reloaded` message in English and German resources

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868389409d8832ea4791261bc96862d