### PR TITLE
Fix null world lookup

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -84,15 +84,19 @@ public class DatabaseManager {
                 if (rs.next()) {
                     if (plugin.isSyncCoordinates() || plugin.isSyncPosition()) {
                         String worldName = rs.getString("world");
-                        World world = Bukkit.getWorld(worldName);
-                        if (world != null) {
-                            Location loc = new Location(world,
-                                    rs.getDouble("x"),
-                                    rs.getDouble("y"),
-                                    rs.getDouble("z"),
-                                    rs.getFloat("yaw"),
-                                    rs.getFloat("pitch"));
-                            Bukkit.getScheduler().runTask(plugin, () -> player.teleport(loc));
+                        if (worldName != null && !worldName.isEmpty()) {
+                            World world = Bukkit.getWorld(worldName);
+                            if (world != null) {
+                                Location loc = new Location(world,
+                                        rs.getDouble("x"),
+                                        rs.getDouble("y"),
+                                        rs.getDouble("z"),
+                                        rs.getFloat("yaw"),
+                                        rs.getFloat("pitch"));
+                                Bukkit.getScheduler().runTask(plugin, () -> player.teleport(loc));
+                            } else {
+                                plugin.getLogger().warning("World " + worldName + " not found when loading data for " + player.getName());
+                            }
                         }
                     }
                     if (plugin.isSyncXp()) {


### PR DESCRIPTION
## Summary
- avoid passing null to Bukkit.getWorld when loading a player's data

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683a2e0620832e984e7d55f4c5409d