### PR TITLE
Add permissions for join/quit messages

### DIFF
--- a/src/main/java/com/example/playerdatasync/PlayerDataListener.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataListener.java
@@ -19,14 +19,18 @@ public class PlayerDataListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        player.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("loading"));
+        if (player.hasPermission("playerdatasync.message.show.loading")) {
+            player.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("loading"));
+        }
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> dbManager.loadPlayer(player));
     }
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
         Player player = event.getPlayer();
-        player.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("saving"));
+        if (player.hasPermission("playerdatasync.message.show.saving")) {
+            player.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("saving"));
+        }
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> dbManager.savePlayer(player));
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,3 +30,9 @@ permissions:
     default: op
   playerdatasync.admin.reload:
     default: op
+  playerdatasync.message.show.loading:
+    description: Allows player to see loading messages
+    default: true
+  playerdatasync.message.show.saving:
+    description: Allows player to see saving messages
+    default: true


### PR DESCRIPTION
## Summary
- add `playerdatasync.message.show.loading` and `playerdatasync.message.show.saving` permissions
- only send join/quit messages if the player has the respective permission

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6e615354832e83c229a7e8dae9d9