### PR TITLE
Add bStats support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ sync:
   position: true
 autosave:
   interval: 5
+language: en
+metrics: true
 ```
+
+`metrics` controls whether anonymous usage statistics are sent to
+[bStats](https://bstats.org/). Set it to `false` if you prefer to
+opt out of metrics collection.
 
 `autosave.interval` controls how often (in minutes) the plugin saves all online
 players to the database. Set it to `0` to disable automatic saves.

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.42.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>3.0.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -10,6 +10,7 @@ import com.example.playerdatasync.DatabaseManager;
 import com.example.playerdatasync.PlayerDataListener;
 import com.example.playerdatasync.SyncCommand;
 import com.example.playerdatasync.UpdateChecker;
+import org.bstats.bukkit.Metrics;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -31,6 +32,7 @@ public class PlayerDataSync extends JavaPlugin {
     private int autosaveInterval;
     private BukkitTask autosaveTask;
     private MessageManager messageManager;
+    private Metrics metrics;
 
     @Override
     public void onEnable() {
@@ -38,6 +40,14 @@ public class PlayerDataSync extends JavaPlugin {
         messageManager = new MessageManager(this);
         String lang = getConfig().getString("language", "en");
         messageManager.load(lang);
+
+        if (getConfig().getBoolean("metrics", true)) {
+            if (metrics == null) {
+                metrics = new Metrics(this, 25037);
+            }
+        } else {
+            metrics = null;
+        }
         databaseType = getConfig().getString("database.type", "mysql");
         try {
             if (databaseType.equalsIgnoreCase("mysql")) {
@@ -207,6 +217,14 @@ public class PlayerDataSync extends JavaPlugin {
 
         String lang = getConfig().getString("language", "en");
         messageManager.load(lang);
+
+        if (getConfig().getBoolean("metrics", true)) {
+            if (metrics == null) {
+                metrics = new Metrics(this, 25037);
+            }
+        } else {
+            metrics = null;
+        }
 
         syncCoordinates = getConfig().getBoolean("sync.coordinates", true);
         syncXp = getConfig().getBoolean("sync.xp", true);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,3 +23,6 @@ autosave:
   interval: 5 # minutes between automatic saves, 0 to disable
 
 language: en
+
+# Enable or disable metrics collection by bStats
+metrics: true


### PR DESCRIPTION
## Summary
- integrate bStats to collect anonymous plugin usage
- document new config setting
- include bStats dependency

## Testing
- `mvn -q test` *(fails: `bash: mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a78ade4a4832ea7aa432e4c1aa925