### PR TITLE
Fix missing metrics by shading bStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ mvn package
 
 The resulting jar can be found in `target/`.
 
+The build process uses the Maven Shade plugin to bundle required
+dependencies (such as bStats) directly into the final jar, so no
+additional libraries need to be installed on the server.
+
 ## Configuration
 
 `config.yml` contains the database connection settings and options to control which

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,27 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.bstats</pattern>
+                                    <shadedPattern>com.example.playerdatasync.bstats</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary
- bundle the bStats library using the Maven Shade plugin
- note that dependencies are included in the README

## Testing
- `mvn -q package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7b506ef4832e9458a87a5db0656b