### PR TITLE
Fix race condition on server switch

### DIFF
--- a/src/main/java/com/example/playerdatasync/PlayerDataListener.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataListener.java
@@ -31,6 +31,10 @@ public class PlayerDataListener implements Listener {
         if (player.hasPermission("playerdatasync.message.show.saving")) {
             player.sendMessage(plugin.getMessageManager().get("prefix") + " " + plugin.getMessageManager().get("saving"));
         }
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> dbManager.savePlayer(player));
+        // Save data synchronously so the database is updated before the player
+        // joins another server. Using an async task here can lead to race
+        // conditions when switching servers quickly via BungeeCord or similar
+        // proxies, causing recent changes not to be stored in time.
+        dbManager.savePlayer(player);
     }
 }


### PR DESCRIPTION
## Summary
- run `savePlayer` synchronously on `PlayerQuit`

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6887dace29ec832eb5d5b90dd18154e7