### PR TITLE
Reduce autosave interval to one second

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ sync:
 # Automatic Save Configuration
 autosave:
   enabled: true
-  interval: 5           # minutes between automatic saves, 0 to disable
+  interval: 1           # seconds between automatic saves, 0 to disable
   on_world_change: true # save when player changes world
   on_death: true        # save when player dies
   async: true           # perform saves asynchronously
@@ -189,7 +189,7 @@ metrics:
 [bStats](https://bstats.org/). Set it to `false` if you prefer to
 opt out of metrics collection.
 
-`autosave.interval` controls how often (in minutes) the plugin saves all online
+`autosave.interval` controls how often (in seconds) the plugin saves all online
 players to the database. Set it to `0` to disable automatic saves.
 
 Update the database values to match your environment. Set any of the `sync` options to

--- a/src/main/java/com/example/playerdatasync/ConfigManager.java
+++ b/src/main/java/com/example/playerdatasync/ConfigManager.java
@@ -156,7 +156,7 @@ public class ConfigManager {
         
         // Autosave configuration
         addDefaultIfMissing("autosave.enabled", true);
-        addDefaultIfMissing("autosave.interval", 5);
+        addDefaultIfMissing("autosave.interval", 1);
         addDefaultIfMissing("autosave.on_world_change", true);
         addDefaultIfMissing("autosave.on_death", true);
         addDefaultIfMissing("autosave.async", true);
@@ -234,10 +234,10 @@ public class ConfigManager {
         }
         
         // Validate autosave interval
-        int interval = config.getInt("autosave.interval", 5);
+        int interval = config.getInt("autosave.interval", 1);
         if (interval < 0) {
-            warnings.add("Invalid autosave interval: " + interval + ". Using 5 minutes as default.");
-            config.set("autosave.interval", 5);
+            warnings.add("Invalid autosave interval: " + interval + ". Using 1 second as default.");
+            config.set("autosave.interval", 1);
         }
         
         // Validate cache size

--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -49,7 +49,7 @@ public class PlayerDataSync extends JavaPlugin {
     private DatabaseManager databaseManager;
     private ConfigManager configManager;
     private BackupManager backupManager;
-    private int autosaveInterval;
+    private int autosaveIntervalSeconds;
     private BukkitTask autosaveTask;
     private MessageManager messageManager;
     private Metrics metrics;
@@ -179,10 +179,10 @@ public class PlayerDataSync extends JavaPlugin {
 
         loadSyncSettings();
 
-        autosaveInterval = getConfig().getInt("autosave.interval", 5);
+        autosaveIntervalSeconds = getConfig().getInt("autosave.interval", 1);
 
-        if (autosaveInterval > 0) {
-            long ticks = autosaveInterval * 1200L;
+        if (autosaveIntervalSeconds > 0) {
+            long ticks = autosaveIntervalSeconds * 20L;
             autosaveTask = Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> {
                 try {
                     int savedCount = 0;
@@ -206,6 +206,7 @@ public class PlayerDataSync extends JavaPlugin {
                     getLogger().severe("Error during autosave: " + e.getMessage());
                 }
             }, ticks, ticks);
+            getLogger().info("Autosave task scheduled with interval: " + autosaveIntervalSeconds + " seconds");
         }
 
         databaseManager = new DatabaseManager(this);
@@ -471,15 +472,15 @@ public class PlayerDataSync extends JavaPlugin {
 
         loadSyncSettings();
 
-        int newInterval = getConfig().getInt("autosave.interval", 5);
-        if (newInterval != autosaveInterval) {
-            autosaveInterval = newInterval;
+        int newIntervalSeconds = getConfig().getInt("autosave.interval", 1);
+        if (newIntervalSeconds != autosaveIntervalSeconds) {
+            autosaveIntervalSeconds = newIntervalSeconds;
             if (autosaveTask != null) {
                 autosaveTask.cancel();
                 autosaveTask = null;
             }
-            if (autosaveInterval > 0) {
-                long ticks = autosaveInterval * 1200L;
+            if (autosaveIntervalSeconds > 0) {
+                long ticks = autosaveIntervalSeconds * 20L;
                 autosaveTask = Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> {
                     try {
                         int savedCount = 0;
@@ -503,7 +504,7 @@ public class PlayerDataSync extends JavaPlugin {
                         getLogger().severe("Error during autosave: " + e.getMessage());
                     }
                 }, ticks, ticks);
-                getLogger().info("Autosave task restarted with interval: " + autosaveInterval + " minutes");
+                getLogger().info("Autosave task restarted with interval: " + autosaveIntervalSeconds + " seconds");
             }
         }
     }
@@ -716,7 +717,7 @@ public class PlayerDataSync extends JavaPlugin {
                 "  economy: false\n" +
                 "autosave:\n" +
                 "  enabled: true\n" +
-                "  interval: 5\n" +
+                "  interval: 1\n" +
                 "  on_world_change: true\n" +
                 "  on_death: true\n" +
                 "  async: true\n" +

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,7 +65,7 @@ sync:
 # Automatic Save Configuration
 autosave:
   enabled: true
-  interval: 5           # minutes between automatic saves, 0 to disable
+  interval: 1           # seconds between automatic saves, 0 to disable
   on_world_change: true # save when player changes world
   on_death: true        # save when player dies
   on_server_switch: true # save when player switches servers (BungeeCord)


### PR DESCRIPTION
## Summary
- update the default autosave interval to one second across the configuration and documentation
- adjust the autosave scheduler to use second-based intervals and log the configured cadence

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download Maven plugins due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68de9b46ac7c832ebe0310dac7aa2989