### PR TITLE
Fix invalid ReflectiveOperationException import

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -10,7 +10,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.advancement.AdvancementProgress;
 
-import java.lang.reflect.ReflectiveOperationException;
 import java.sql.*;
 import java.util.Iterator;
 import java.util.UUID;


### PR DESCRIPTION
## Summary
- remove the incorrect java.lang.reflect import for ReflectiveOperationException so the build can compile on JDK 21

## Testing
- mvn -q -DskipTests compile *(fails: cannot download maven-resources-plugin due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68dea4379a70832e8702d99e764b0e66