### PR TITLE
Improve server switching safety and responsiveness

### DIFF
--- a/src/main/java/com/example/playerdatasync/ServerSwitchListener.java
+++ b/src/main/java/com/example/playerdatasync/ServerSwitchListener.java
@@ -1,0 +1,93 @@
+package com.example.playerdatasync;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Handles server switch requests that originate from in-game commands.
+ * This ensures player data is safely stored before a BungeeCord transfer
+ * and prevents duplication by clearing the inventory only after a successful save.
+ */
+public class ServerSwitchListener implements Listener {
+    private final PlayerDataSync plugin;
+    private final DatabaseManager databaseManager;
+    private final MessageManager messageManager;
+
+    public ServerSwitchListener(PlayerDataSync plugin, DatabaseManager databaseManager) {
+        this.plugin = plugin;
+        this.databaseManager = databaseManager;
+        this.messageManager = plugin.getMessageManager();
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onServerSwitchCommand(PlayerCommandPreprocessEvent event) {
+        if (!plugin.isBungeecordIntegrationEnabled()) {
+            return;
+        }
+
+        String rawMessage = event.getMessage();
+        if (rawMessage == null || rawMessage.isEmpty()) {
+            return;
+        }
+
+        String trimmed = rawMessage.trim();
+        if (!trimmed.startsWith("/")) {
+            return;
+        }
+
+        String[] parts = trimmed.split("\\s+");
+        if (parts.length == 0) {
+            return;
+        }
+
+        String baseCommand = parts[0].startsWith("/") ? parts[0].substring(1) : parts[0];
+        if (!baseCommand.equalsIgnoreCase("server")) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (parts.length < 2) {
+            player.sendMessage(messageManager.get("prefix") + " "
+                + messageManager.get("invalid_syntax").replace("{usage}", "/server <server>"));
+            return;
+        }
+
+        String targetServer = parts[1];
+        event.setCancelled(true);
+
+        if (player.hasPermission("playerdatasync.message.show.saving")) {
+            player.sendMessage(messageManager.get("prefix") + " " + messageManager.get("server_switch_save"));
+        }
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            boolean saveSuccessful = databaseManager.savePlayer(player);
+
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (!player.isOnline()) {
+                    return;
+                }
+
+                if (saveSuccessful) {
+                    if (player.hasPermission("playerdatasync.message.show.saving")) {
+                        player.sendMessage(messageManager.get("prefix") + " " + messageManager.get("server_switch_saved"));
+                    }
+
+                    player.getInventory().clear();
+                    player.getInventory().setArmorContents(new ItemStack[player.getInventory().getArmorContents().length]);
+                    player.getInventory().setItemInOffHand(null);
+                    player.updateInventory();
+                } else if (player.hasPermission("playerdatasync.message.show.errors")) {
+                    player.sendMessage(messageManager.get("prefix") + " "
+                        + messageManager.get("sync_failed").replace("{error}", "Unable to save data before server switch."));
+                }
+
+                plugin.connectPlayerToServer(player, targetServer);
+            });
+        });
+    }
+}

--- a/src/main/java/com/example/playerdatasync/SyncCommand.java
+++ b/src/main/java/com/example/playerdatasync/SyncCommand.java
@@ -160,11 +160,16 @@ public class SyncCommand implements CommandExecutor, TabCompleter {
             }
             
             try {
-                plugin.getDatabaseManager().savePlayer(target);
-                sender.sendMessage(messageManager.get("prefix") + " " + 
-                    messageManager.get("manual_save_success"));
+                if (plugin.getDatabaseManager().savePlayer(target)) {
+                    sender.sendMessage(messageManager.get("prefix") + " " +
+                        messageManager.get("manual_save_success"));
+                } else {
+                    sender.sendMessage(messageManager.get("prefix") + " " +
+                        messageManager.get("manual_save_failed").replace("{error}",
+                            "Unable to persist player data. See console for details."));
+                }
             } catch (Exception e) {
-                sender.sendMessage(messageManager.get("prefix") + " " + 
+                sender.sendMessage(messageManager.get("prefix") + " " +
                     messageManager.get("manual_save_failed").replace("{error}", e.getMessage()));
             }
         } else {
@@ -172,13 +177,14 @@ public class SyncCommand implements CommandExecutor, TabCompleter {
             try {
                 int savedCount = 0;
                 for (Player player : Bukkit.getOnlinePlayers()) {
-                    plugin.getDatabaseManager().savePlayer(player);
-                    savedCount++;
+                    if (plugin.getDatabaseManager().savePlayer(player)) {
+                        savedCount++;
+                    }
                 }
-                sender.sendMessage(messageManager.get("prefix") + " " + 
+                sender.sendMessage(messageManager.get("prefix") + " " +
                     "Saved data for " + savedCount + " players.");
             } catch (Exception e) {
-                sender.sendMessage(messageManager.get("prefix") + " " + 
+                sender.sendMessage(messageManager.get("prefix") + " " +
                     messageManager.get("manual_save_failed").replace("{error}", e.getMessage()));
             }
         }


### PR DESCRIPTION
## Summary
- add a ServerSwitchListener that intercepts /server requests, saves player data, clears inventories on success, and forwards players via the BungeeCord channel
- expose BungeeCord integration helpers and register/unregister the plugin messaging channel during enable, disable, and reload
- return a success flag from database saves, adjust autosave/manual save logic accordingly, and reduce the join load delay to minimise empty inventories

## Testing
- mvn -q -DskipTests package *(fails: Maven Central responded with 403 while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68f018463d08832e93417b41c2a0c4c3