### PR TITLE
Fix SQLite save timestamp usage

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -131,7 +131,7 @@ public class DatabaseManager {
 
     public boolean savePlayer(Player player) {
         long startTime = System.currentTimeMillis();
-        String sql = "REPLACE INTO player_data (uuid, world, x, y, z, yaw, pitch, xp, gamemode, enderchest, inventory, armor, offhand, effects, statistics, attributes, health, hunger, saturation, advancements, economy, last_save, server_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,NOW(),?)";
+        String sql = "REPLACE INTO player_data (uuid, world, x, y, z, yaw, pitch, xp, gamemode, enderchest, inventory, armor, offhand, effects, statistics, attributes, health, hunger, saturation, advancements, economy, last_save, server_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
         try {
             PlayerSnapshot snapshot;
@@ -175,7 +175,8 @@ public class DatabaseManager {
                 ps.setFloat(19, snapshot.saturation);
                 ps.setString(20, snapshot.advancementsData);
                 ps.setDouble(21, snapshot.economyBalance);
-                ps.setString(22, plugin.getConfig().getString("server.id", "default"));
+                ps.setTimestamp(22, new Timestamp(System.currentTimeMillis()));
+                ps.setString(23, plugin.getConfig().getString("server.id", "default"));
 
                 ps.executeUpdate();
 


### PR DESCRIPTION
## Summary
- replace the hard-coded NOW() expression in the player data upsert with a JDBC parameter so it works on all database engines
- explicitly write the current timestamp from Java when saving player data to keep the last_save column updated

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f01ef71c48832e838c72f7e2e5494d