### PR TITLE
Remove unreachable return in DatabaseManager

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -214,7 +214,6 @@ public class DatabaseManager {
             plugin.getLogger().severe("Unexpected error saving player " + player.getName() + ": " + e.getMessage());
             return false;
         }
-        return false;
     }
 
     private PlayerSnapshot capturePlayerSnapshot(Player player) {


### PR DESCRIPTION
## Summary
- remove the unreachable return statement at the end of the player save routine to resolve the compiler error

## Testing
- mvn -q -DskipTests compile *(fails: unable to download maven-resources-plugin due to HTTP 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68f0225e188c832e9cc2d9852a939c3a