### PR TITLE
Fix advancement counting loop

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -500,6 +500,8 @@ public class DatabaseManager {
                 // CRITICAL: Add timeout check for counting achievements with hard limit
                 Iterator<Advancement> it = Bukkit.getServer().advancementIterator();
                 while (it.hasNext() && totalAdvancements < MAX_COUNT_ATTEMPTS) {
+                    // Advance the iterator to prevent hasNext() from always returning true
+                    it.next();
                     totalAdvancements++;
                     
                     // CRITICAL: Check timeout every 50 achievements to prevent freezing


### PR DESCRIPTION
## Summary
- ensure the advancement iterator is advanced during achievement counting to avoid hitting the hard safety limit
- add an inline comment clarifying why the iterator needs to be consumed

## Testing
- `mvn -q -e -DskipTests package` *(fails: blocked from downloading Maven resources in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0246b109c832e94406e2b43eb3ca8