### PR TITLE
Use base attribute values when serializing player data

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -680,7 +680,7 @@ public class DatabaseManager {
                             
                             if (instance != null) {
                                 if (sb.length() > 0) sb.append(";");
-                                sb.append(attrName).append(",").append(instance.getValue());
+                                sb.append(attrName).append(",").append(instance.getBaseValue());
                             }
                         } catch (Exception e) {
                             // Some attributes might not be applicable, skip them
@@ -696,7 +696,7 @@ public class DatabaseManager {
                             org.bukkit.attribute.AttributeInstance instance = player.getAttribute(attr);
                             if (instance != null) {
                                 if (sb.length() > 0) sb.append(";");
-                                sb.append(attr.name()).append(",").append(instance.getValue());
+                                sb.append(attr.name()).append(",").append(instance.getBaseValue());
                             }
                         } catch (Exception ex) {
                             // Some attributes might not be applicable, skip them
@@ -711,7 +711,7 @@ public class DatabaseManager {
                         org.bukkit.attribute.AttributeInstance instance = player.getAttribute(attr);
                         if (instance != null) {
                             if (sb.length() > 0) sb.append(";");
-                            sb.append(attr.name()).append(",").append(instance.getValue());
+                            sb.append(attr.name()).append(",").append(instance.getBaseValue());
                         }
                     } catch (Exception ex) {
                         // Some attributes might not be applicable, skip them


### PR DESCRIPTION
## Summary
- store the base attribute value when serializing player attributes so other plugins do not have their modifiers duplicated on load

## Testing
- mvn -q -DskipTests package *(fails: blocked by network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0ab2a4130832e9f8f12ed456a5f73