### PR TITLE
Improve logging level handling and debug controls

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -296,10 +296,10 @@ public class DatabaseManager {
         if (plugin.isSyncEconomy()) {
             double balance = getPlayerBalance(player);
             snapshot.economyBalance = balance;
-            plugin.getLogger().info("DEBUG: Saving economy balance for " + player.getName() + ": " + balance);
+            plugin.logDebug("Saving economy balance for " + player.getName() + ": " + balance);
         } else {
             snapshot.economyBalance = 0.0;
-            plugin.getLogger().info("DEBUG: Economy sync disabled, setting balance to 0.0 for " + player.getName());
+            plugin.logDebug("Economy sync disabled, setting balance to 0.0 for " + player.getName());
         }
 
         return snapshot;
@@ -447,10 +447,10 @@ public class DatabaseManager {
                         }
                         if (plugin.isSyncEconomy()) {
                             double balance = rs.getDouble("economy");
-                            plugin.getLogger().info("DEBUG: Loading economy balance for " + player.getName() + ": " + balance);
+                            plugin.logDebug("Loading economy balance for " + player.getName() + ": " + balance);
                             Bukkit.getScheduler().runTask(plugin, () -> setPlayerBalance(player, balance));
                         } else {
-                            plugin.getLogger().info("DEBUG: Economy sync disabled, skipping balance load for " + player.getName());
+                            plugin.logDebug("Economy sync disabled, skipping balance load for " + player.getName());
                         }
                     }
                 }
@@ -959,7 +959,7 @@ public class DatabaseManager {
             }
 
             double balance = economy.getBalance(player);
-            plugin.getLogger().info("DEBUG: Retrieved balance for " + player.getName() + ": " + balance);
+            plugin.logDebug("Retrieved balance for " + player.getName() + ": " + balance);
             return balance;
         } catch (Exception e) {
             plugin.getLogger().warning("Error getting player balance for " + player.getName() + ": " + e.getMessage());
@@ -977,23 +977,23 @@ public class DatabaseManager {
             return;
         }
 
-        plugin.getLogger().info("DEBUG: Attempting to set balance for " + player.getName() + " to " + balance);
+        plugin.logDebug("Attempting to set balance for " + player.getName() + " to " + balance);
 
         try {
             if (!economy.hasAccount(player)) {
                 economy.createPlayerAccount(player);
             }
 
-            plugin.getLogger().info("DEBUG: Economy provider found: " + economy.getName());
+            plugin.logDebug("Economy provider found: " + economy.getName());
 
             try {
                 java.lang.reflect.Method setBalanceMethod =
                     economy.getClass().getMethod("setBalance", org.bukkit.OfflinePlayer.class, double.class);
                 setBalanceMethod.invoke(economy, player, balance);
-                plugin.getLogger().info("DEBUG: Set balance for " + player.getName() + " to " + balance + " using setBalance method");
+                plugin.logDebug("Set balance for " + player.getName() + " to " + balance + " using setBalance method");
                 return;
             } catch (NoSuchMethodException e) {
-                plugin.getLogger().info("DEBUG: setBalance method not available, using deposit/withdraw approach");
+                plugin.logDebug("setBalance method not available, using deposit/withdraw approach");
             } catch (ReflectiveOperationException reflectiveError) {
                 plugin.getLogger().warning("Failed to invoke setBalance on economy provider " + economy.getName() + ": " + reflectiveError.getMessage());
             }
@@ -1001,10 +1001,10 @@ public class DatabaseManager {
             double currentBalance = economy.getBalance(player);
             double difference = balance - currentBalance;
 
-            plugin.getLogger().info("DEBUG: Current balance: " + currentBalance + ", Target balance: " + balance + ", Difference: " + difference);
+            plugin.logDebug("Current balance: " + currentBalance + ", Target balance: " + balance + ", Difference: " + difference);
 
             if (Math.abs(difference) < 0.01) {
-                plugin.getLogger().info("DEBUG: Balance is already correct (within tolerance)");
+                plugin.logDebug("Balance is already correct (within tolerance)");
                 return;
             }
 
@@ -1015,14 +1015,14 @@ public class DatabaseManager {
                     plugin.getLogger().warning("Failed to deposit funds for " + player.getName() + ": " + response.errorMessage);
                     return;
                 }
-                plugin.getLogger().info("DEBUG: Added " + difference + " to " + player.getName() + "'s balance (now: " + balance + ")");
+                plugin.logDebug("Added " + difference + " to " + player.getName() + "'s balance (now: " + balance + ")");
             } else {
                 response = economy.withdrawPlayer(player, Math.abs(difference));
                 if (!response.transactionSuccess()) {
                     plugin.getLogger().warning("Failed to withdraw funds for " + player.getName() + ": " + response.errorMessage);
                     return;
                 }
-                plugin.getLogger().info("DEBUG: Removed " + Math.abs(difference) + " from " + player.getName() + "'s balance (now: " + balance + ")");
+                plugin.logDebug("Removed " + Math.abs(difference) + " from " + player.getName() + "'s balance (now: " + balance + ")");
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/example/playerdatasync/PlayerDataListener.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataListener.java
@@ -114,14 +114,14 @@ public class PlayerDataListener implements Listener {
         
         Player player = event.getPlayer();
         
-        plugin.getLogger().info("DEBUG: Player " + player.getName() + " was kicked, saving data");
+        plugin.logDebug("Player " + player.getName() + " was kicked, saving data");
         
         try {
             long startTime = System.currentTimeMillis();
             dbManager.savePlayer(player);
             long endTime = System.currentTimeMillis();
             
-            plugin.getLogger().info("DEBUG: Saved data for kicked player " + player.getName() + 
+            plugin.logDebug("Saved data for kicked player " + player.getName() + 
                 " in " + (endTime - startTime) + "ms");
             
         } catch (Exception e) {
@@ -141,7 +141,7 @@ public class PlayerDataListener implements Listener {
             if (event.getTo() != null && event.getTo().getWorld() != null) {
                 String currentServer = plugin.getConfig().getString("server.id", "default");
                 
-                plugin.getLogger().info("DEBUG: Player " + player.getName() + " teleported via plugin, saving data");
+                plugin.logDebug("Player " + player.getName() + " teleported via plugin, saving data");
                 
                 // Save data before teleport
                 try {
@@ -149,7 +149,7 @@ public class PlayerDataListener implements Listener {
                     dbManager.savePlayer(player);
                     long endTime = System.currentTimeMillis();
                     
-                    plugin.getLogger().info("DEBUG: Saved data for teleporting player " + player.getName() + 
+                    plugin.logDebug("Saved data for teleporting player " + player.getName() + 
                         " in " + (endTime - startTime) + "ms");
                     
                 } catch (Exception e) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -129,10 +129,10 @@ messages:
   
 # Logging and Debugging
 logging:
-  level: INFO           # Log level: DEBUG, INFO, WARN, ERROR
+  level: INFO           # Log level: DEBUG, INFO, WARN, ERROR (also accepts WARNING/SEVERE/OFF)
   log_database: false   # log database operations
   log_performance: false # log performance metrics
-  debug_mode: false     # enable debug mode for troubleshooting
+  debug_mode: false     # enable verbose debug messages (set to true only when troubleshooting)
 
 # Update Checker
 update_checker:


### PR DESCRIPTION
## Summary
- normalize configured log levels so common aliases like WARN and DEBUG are accepted
- apply the configured logger level at startup and gate debug messages behind the debug_mode flag
- update economy-related debug logging to use the central helper and clarify config comments

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin because access to Maven Central is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f742145b68832e915c876ba6101feb