### PR TITLE
Respect performance logging configuration

### DIFF
--- a/src/main/java/com/example/playerdatasync/DatabaseManager.java
+++ b/src/main/java/com/example/playerdatasync/DatabaseManager.java
@@ -593,8 +593,11 @@ public class DatabaseManager {
             }
             
             if (count > 0) {
-                plugin.getLogger().info("Serialized " + count + " achievements for " + player.getName() + " in " + 
-                    (System.currentTimeMillis() - startTime) + "ms");
+                ConfigManager configManager = plugin.getConfigManager();
+                if (configManager != null && configManager.isPerformanceLoggingEnabled()) {
+                    plugin.getLogger().info("Serialized " + count + " achievements for " + player.getName() + " in " +
+                        (System.currentTimeMillis() - startTime) + "ms");
+                }
             }
             
             // CRITICAL: Log if we hit the limit

--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -222,8 +222,8 @@ public class PlayerDataSync extends JavaPlugin {
                     }
                     
                     long endTime = System.currentTimeMillis();
-                    if (savedCount > 0) {
-                        getLogger().info("Autosaved data for " + savedCount + " players in " + 
+                    if (savedCount > 0 && isPerformanceLoggingEnabled()) {
+                        getLogger().info("Autosaved data for " + savedCount + " players in " +
                             (endTime - startTime) + "ms");
                     }
                 } catch (Exception e) {
@@ -528,8 +528,8 @@ public class PlayerDataSync extends JavaPlugin {
                         }
                         
                         long endTime = System.currentTimeMillis();
-                        if (savedCount > 0) {
-                            getLogger().info("Autosaved data for " + savedCount + " players in " + 
+                        if (savedCount > 0 && isPerformanceLoggingEnabled()) {
+                            getLogger().info("Autosaved data for " + savedCount + " players in " +
                                 (endTime - startTime) + "ms");
                         }
                     } catch (Exception e) {
@@ -897,5 +897,9 @@ public class PlayerDataSync extends JavaPlugin {
 
     public boolean isDebugEnabled() {
         return configManager != null && configManager.isDebugMode();
+    }
+
+    private boolean isPerformanceLoggingEnabled() {
+        return configManager != null && configManager.isPerformanceLoggingEnabled();
     }
 }


### PR DESCRIPTION
## Summary
- gate autosave performance logs behind the logging.log_performance configuration flag
- only log achievement serialization metrics when performance logging is enabled

## Testing
- mvn -q -DskipTests package *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68f747ef440c832eb41cdec7c121394e