### PR TITLE
Ensure plugin metadata follows project version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,12 @@
     </profiles>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: PlayerDataSync
 main: com.example.playerdatasync.PlayerDataSync
-version: 1.2.1-SNAPSHOT
+version: ${project.version}
 api-version: "1.20"
 load: STARTUP
 authors: [DerGamer09]


### PR DESCRIPTION
## Summary
- filter resource processing so plugin.yml can use Maven properties
- reference the project version in plugin.yml to keep the reported version in sync with the build

## Testing
- `mvn -q package` *(fails: unable to download maven-resources-plugin due to HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690c711e43a8832e8669ff511c1affdf