### PR TITLE
Embed editor API configuration in plugin

### DIFF
--- a/src/main/java/com/example/playerdatasync/AdvancementSyncManager.java
+++ b/src/main/java/com/example/playerdatasync/AdvancementSyncManager.java
@@ -70,7 +70,7 @@ public class AdvancementSyncManager implements Listener {
     }
 
     public void recordAdvancement(UUID uuid, String key) {
-        PlayerAdvancementState state = states.computeIfAbsent(uuid, PlayerAdvancementState::new);
+        PlayerAdvancementState state = states.computeIfAbsent(uuid, key -> new PlayerAdvancementState());
         state.completedAdvancements.add(key);
         if (state.importInProgress) {
             state.pendingDuringImport.add(key);
@@ -83,7 +83,7 @@ public class AdvancementSyncManager implements Listener {
             return;
         }
 
-        PlayerAdvancementState state = states.computeIfAbsent(player.getUniqueId(), PlayerAdvancementState::new);
+        PlayerAdvancementState state = states.computeIfAbsent(player.getUniqueId(), key -> new PlayerAdvancementState());
         if (state.importFinished || state.importInProgress) {
             return;
         }
@@ -99,7 +99,7 @@ public class AdvancementSyncManager implements Listener {
     }
 
     public void seedFromDatabase(UUID uuid, String csv) {
-        PlayerAdvancementState state = states.computeIfAbsent(uuid, PlayerAdvancementState::new);
+        PlayerAdvancementState state = states.computeIfAbsent(uuid, key -> new PlayerAdvancementState());
         state.completedAdvancements.clear();
         state.pendingDuringImport.clear();
 
@@ -128,7 +128,7 @@ public class AdvancementSyncManager implements Listener {
     }
 
     public String serializeForSave(Player player) {
-        PlayerAdvancementState state = states.computeIfAbsent(player.getUniqueId(), PlayerAdvancementState::new);
+        PlayerAdvancementState state = states.computeIfAbsent(player.getUniqueId(), key -> new PlayerAdvancementState());
 
         if (!state.importFinished && !state.importInProgress) {
             if (plugin.getConfig().getBoolean("performance.automatic_player_advancement_import", true)) {
@@ -146,7 +146,7 @@ public class AdvancementSyncManager implements Listener {
     }
 
     public void queuePlayerImport(Player player, boolean force) {
-        PlayerAdvancementState state = states.computeIfAbsent(player.getUniqueId(), PlayerAdvancementState::new);
+        PlayerAdvancementState state = states.computeIfAbsent(player.getUniqueId(), key -> new PlayerAdvancementState());
         if (!force) {
             if (state.importInProgress || state.importFinished) {
                 return;

--- a/src/main/java/com/example/playerdatasync/PlayerDataSync.java
+++ b/src/main/java/com/example/playerdatasync/PlayerDataSync.java
@@ -150,9 +150,7 @@ public class PlayerDataSync extends JavaPlugin {
         }
 
         editorIntegrationManager = new EditorIntegrationManager(this);
-        if (editorIntegrationManager.isEnabled()) {
-            editorIntegrationManager.start();
-        }
+        editorIntegrationManager.start();
         // Initialize database connection
         databaseType = getConfig().getString("database.type", "mysql");
         try {

--- a/src/main/java/com/example/playerdatasync/SyncCommand.java
+++ b/src/main/java/com/example/playerdatasync/SyncCommand.java
@@ -294,7 +294,12 @@ public class SyncCommand implements CommandExecutor, TabCompleter {
         EditorIntegrationManager manager = plugin.getEditorIntegrationManager();
         String prefix = messageManager.get("prefix") + " ";
 
-        if (manager == null || !manager.isEnabled()) {
+        if (manager == null) {
+            sender.sendMessage(prefix + messageManager.get("editor_disabled"));
+            return true;
+        }
+
+        if (!manager.hasConfiguredApiKey()) {
             sender.sendMessage(prefix + messageManager.get("editor_disabled"));
             return true;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -125,14 +125,6 @@ integrations:
   vault: true           # enable Vault integration for economy
   placeholderapi: false # enable PlaceholderAPI support
 
-# Web Editor Integration
-editor:
-  enabled: false             # enable remote web editor integration
-  base_url: https://pds.devvoxel.de/api # API base URL for the editor services
-  api_key: ""               # API key provided by the PlayerDataSync dashboard
-  server_id: ""             # optional override, defaults to server.id when empty
-  heartbeat_interval: 60     # seconds between automatic heartbeat updates (0 to disable)
-
 # Message Configuration
 messages:
   enabled: true         # enable player messages

--- a/src/main/resources/messages_de.yml
+++ b/src/main/resources/messages_de.yml
@@ -95,7 +95,7 @@ integration_bungeecord_enabled: "&aBungeeCord-Modus aktiviert."
 integration_placeholderapi_enabled: "&aPlaceholderAPI-Integration aktiviert."
 
 # Editor-Integrationsnachrichten
-editor_disabled: "&cDie Editor-Integration ist deaktiviert."
+editor_disabled: "&cDie Editor-Integration ist nicht konfiguriert. Setze PDS_EDITOR_API_KEY oder die System-Property pds.editor.apiKey."
 editor_player_required: "&cBitte gib einen Spieler an, wenn du den Befehl von der Konsole nutzt."
 editor_token_generating: "&7Fordere Editor-Zugang für &b{player}&7 an..."
 editor_token_success: "&aEditor-Link:&r {url}"

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -95,7 +95,7 @@ integration_bungeecord_enabled: "&aBungeeCord mode enabled."
 integration_placeholderapi_enabled: "&aPlaceholderAPI integration enabled."
 
 # Editor Integration Messages
-editor_disabled: "&cThe web editor integration is disabled."
+editor_disabled: "&cThe web editor integration is not configured. Set PDS_EDITOR_API_KEY or the system property pds.editor.apiKey."
 editor_player_required: "&cYou must provide a player when running this command from console."
 editor_token_generating: "&7Requesting editor access for &b{player}&7..."
 editor_token_success: "&aEditor link:&r {url}"


### PR DESCRIPTION
## Summary
- hardcode the editor API endpoint and heartbeat configuration inside the plugin and resolve credentials from environment or system properties
- remove the deprecated `editor.*` configuration block and migrate existing configs to drop those entries
- update localized admin messaging to describe the new API key configuration path

## Testing
- mvn -q -DskipTests compile *(fails: Maven cannot download maven-resources-plugin because of 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_690cc096b67c832e8dc3d33f3a3c8cb3