### PR TITLE
Fix duplicate lambda parameter in advancement sync

### DIFF
--- a/src/main/java/com/example/playerdatasync/AdvancementSyncManager.java
+++ b/src/main/java/com/example/playerdatasync/AdvancementSyncManager.java
@@ -70,7 +70,7 @@ public class AdvancementSyncManager implements Listener {
     }
 
     public void recordAdvancement(UUID uuid, String key) {
-        PlayerAdvancementState state = states.computeIfAbsent(uuid, key -> new PlayerAdvancementState());
+        PlayerAdvancementState state = states.computeIfAbsent(uuid, id -> new PlayerAdvancementState());
         state.completedAdvancements.add(key);
         if (state.importInProgress) {
             state.pendingDuringImport.add(key);


### PR DESCRIPTION
## Summary
- rename the computeIfAbsent lambda parameter in recordAdvancement to avoid re-declaration of the method argument

## Testing
- `mvn -q -DskipTests compile` *(fails: status code 403 when downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_690cc4dce71c832e96228dd6c619bb40