### PR TITLE
Allow editor integration without API key

### DIFF
--- a/src/main/java/com/example/playerdatasync/SyncCommand.java
+++ b/src/main/java/com/example/playerdatasync/SyncCommand.java
@@ -299,11 +299,6 @@ public class SyncCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
-        if (!manager.hasConfiguredApiKey()) {
-            sender.sendMessage(prefix + messageManager.get("editor_disabled"));
-            return true;
-        }
-
         String action = args.length > 1 ? args[1].toLowerCase() : "token";
 
         switch (action) {


### PR DESCRIPTION
## Summary
- allow the editor integration manager to operate without a configured API key and log when requests are unauthenticated
- derive a default editor page link from returned tokens when the API response does not include a URL
- let the /pds editor command issue tokens even when no API key is configured

## Testing
- mvn -q -DskipTests package *(fails: Maven Central returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_690cc712cae4832eb9e41dfaa1d965a6