### PR TITLE
Add inventory viewer integration support

### DIFF
--- a/src/main/java/com/example/playerdatasync/ConfigManager.java
+++ b/src/main/java/com/example/playerdatasync/ConfigManager.java
@@ -20,7 +20,7 @@ public class ConfigManager {
     private File configFile;
     
     // Configuration version for migration
-    private static final int CURRENT_CONFIG_VERSION = 5;
+    private static final int CURRENT_CONFIG_VERSION = 6;
     
     public ConfigManager(PlayerDataSync plugin) {
         this.plugin = plugin;
@@ -78,6 +78,11 @@ public class ConfigManager {
 
             if (fromVersion < 5) {
                 migrateFromV4ToV5();
+                fromVersion = 5;
+            }
+
+            if (fromVersion < 6) {
+                migrateFromV5ToV6();
             }
 
             plugin.getLogger().info("Configuration migration completed successfully.");
@@ -148,6 +153,11 @@ public class ConfigManager {
             plugin.getLogger().info("Removing deprecated editor.* configuration entries.");
             config.set("editor", null);
         }
+    }
+
+    private void migrateFromV5ToV6() {
+        addDefaultIfMissing("integrations.invsee", true);
+        addDefaultIfMissing("integrations.openinv", true);
     }
     
     /**
@@ -244,6 +254,9 @@ public class ConfigManager {
         // Metrics configuration
         addDefaultIfMissing("metrics.bstats", true);
         addDefaultIfMissing("metrics.custom_metrics", true);
+
+        addDefaultIfMissing("integrations.invsee", true);
+        addDefaultIfMissing("integrations.openinv", true);
 
         // Editor integration defaults
         // Messages configuration

--- a/src/main/java/com/example/playerdatasync/InventoryViewerIntegrationManager.java
+++ b/src/main/java/com/example/playerdatasync/InventoryViewerIntegrationManager.java
@@ -1,0 +1,349 @@
+package com.example.playerdatasync;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Provides compatibility with inventory viewing plugins such as InvSee++ and OpenInv.
+ * The manager intercepts their commands and serves data directly from the
+ * PlayerDataSync database so that editing inventories works across servers.
+ */
+public class InventoryViewerIntegrationManager implements Listener {
+    private static final Set<String> INVSEE_COMMANDS = new HashSet<>(Arrays.asList("invsee", "isee"));
+    private static final Set<String> INVSEE_ENDER_COMMANDS = new HashSet<>(Arrays.asList("endersee", "enderinv"));
+    private static final Set<String> OPENINV_COMMANDS = new HashSet<>(Arrays.asList("openinv", "oi"));
+    private static final Set<String> OPENINV_ENDER_COMMANDS = new HashSet<>(Arrays.asList("openender", "enderchest", "openec", "ec"));
+
+    private final PlayerDataSync plugin;
+    private final DatabaseManager databaseManager;
+    private final MessageManager messageManager;
+    private boolean invSeeEnabled;
+    private boolean openInvEnabled;
+    private final ItemStack fillerItem;
+
+    public InventoryViewerIntegrationManager(PlayerDataSync plugin, DatabaseManager databaseManager,
+        boolean invSeeEnabled, boolean openInvEnabled) {
+        this.plugin = plugin;
+        this.databaseManager = databaseManager;
+        this.messageManager = plugin.getMessageManager();
+        this.invSeeEnabled = invSeeEnabled;
+        this.openInvEnabled = openInvEnabled;
+        this.fillerItem = createFillerItem();
+
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        detectExternalPlugins();
+    }
+
+    private void detectExternalPlugins() {
+        if (invSeeEnabled && plugin.getServer().getPluginManager().getPlugin("InvSee++") != null) {
+            plugin.getLogger().info("InvSee++ detected. Routing inventory viewing through PlayerDataSync storage.");
+        }
+        if (openInvEnabled && plugin.getServer().getPluginManager().getPlugin("OpenInv") != null) {
+            plugin.getLogger().info("OpenInv detected. Routing inventory viewing through PlayerDataSync storage.");
+        }
+    }
+
+    public void updateSettings(boolean invSeeEnabled, boolean openInvEnabled) {
+        this.invSeeEnabled = invSeeEnabled;
+        this.openInvEnabled = openInvEnabled;
+    }
+
+    public void shutdown() {
+        HandlerList.unregisterAll(this);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryCommand(PlayerCommandPreprocessEvent event) {
+        if (!invSeeEnabled && !openInvEnabled) {
+            return;
+        }
+
+        String rawMessage = event.getMessage();
+        if (rawMessage == null || rawMessage.isEmpty()) {
+            return;
+        }
+
+        String trimmed = rawMessage.trim();
+        if (!trimmed.startsWith("/")) {
+            return;
+        }
+
+        String[] parts = trimmed.substring(1).split("\\s+");
+        if (parts.length == 0) {
+            return;
+        }
+
+        String baseCommand = parts[0].toLowerCase(Locale.ROOT);
+        boolean inventoryCommand = (invSeeEnabled && INVSEE_COMMANDS.contains(baseCommand))
+            || (openInvEnabled && OPENINV_COMMANDS.contains(baseCommand));
+        boolean enderCommand = (invSeeEnabled && INVSEE_ENDER_COMMANDS.contains(baseCommand))
+            || (openInvEnabled && OPENINV_ENDER_COMMANDS.contains(baseCommand));
+
+        if (!inventoryCommand && !enderCommand) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+
+        if (inventoryCommand && !player.hasPermission("playerdatasync.integration.invsee")) {
+            player.sendMessage(messageManager.get("prefix") + " " + messageManager.get("no_permission"));
+            event.setCancelled(true);
+            return;
+        }
+
+        if (enderCommand && !player.hasPermission("playerdatasync.integration.enderchest")) {
+            player.sendMessage(messageManager.get("prefix") + " " + messageManager.get("no_permission"));
+            event.setCancelled(true);
+            return;
+        }
+
+        if (parts.length < 2) {
+            String usageKey = enderCommand ? "inventory_view_usage_ender" : "inventory_view_usage_inventory";
+            player.sendMessage(messageManager.get("prefix") + " " + messageManager.get(usageKey));
+            event.setCancelled(true);
+            return;
+        }
+
+        String targetName = parts[1];
+        event.setCancelled(true);
+        handleInventoryRequest(player, targetName, enderCommand);
+    }
+
+    private void handleInventoryRequest(Player viewer, String targetName, boolean enderChest) {
+        OfflinePlayer offline = Bukkit.getOfflinePlayer(targetName);
+        UUID targetUuid = offline != null ? offline.getUniqueId() : null;
+        String displayName = offline != null && offline.getName() != null ? offline.getName() : targetName;
+
+        viewer.sendMessage(messageManager.get("prefix") + " "
+            + messageManager.get("inventory_view_loading").replace("{player}", displayName));
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            OfflinePlayerData data;
+            try {
+                data = databaseManager.loadOfflinePlayerData(targetUuid, displayName);
+            } catch (Exception ex) {
+                plugin.getLogger().severe("Failed to load offline data for " + displayName + ": " + ex.getMessage());
+                data = null;
+            }
+
+            if (data == null) {
+                String message = messageManager.get("prefix") + " "
+                    + messageManager.get("inventory_view_open_failed").replace("{player}", displayName);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    if (viewer.isOnline()) {
+                        viewer.sendMessage(message);
+                    }
+                });
+                return;
+            }
+
+            OfflinePlayerData finalData = data;
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (!viewer.isOnline()) {
+                    return;
+                }
+
+                if (!finalData.existsInDatabase()) {
+                    viewer.sendMessage(messageManager.get("prefix") + " "
+                        + messageManager.get("inventory_view_no_data").replace("{player}", finalData.getDisplayName()));
+                }
+
+                if (enderChest) {
+                    openEnderChestInventory(viewer, finalData);
+                } else {
+                    openMainInventory(viewer, finalData);
+                }
+            });
+        });
+    }
+
+    private void openMainInventory(Player viewer, OfflinePlayerData data) {
+        OfflineInventoryHolder holder = new OfflineInventoryHolder(data, false);
+        Inventory inventory = Bukkit.createInventory(holder, 45,
+            messageManager.get("inventory_view_title_inventory").replace("{player}", data.getDisplayName()));
+        holder.setInventory(inventory);
+
+        ItemStack[] main = data.getInventoryContents();
+        for (int slot = 0; slot < 36; slot++) {
+            inventory.setItem(slot, slot < main.length ? main[slot] : null);
+        }
+
+        ItemStack[] armor = data.getArmorContents();
+        inventory.setItem(36, armor.length > 3 ? armor[3] : null); // Helmet position
+        inventory.setItem(37, armor.length > 2 ? armor[2] : null); // Chestplate
+        inventory.setItem(38, armor.length > 1 ? armor[1] : null); // Leggings
+        inventory.setItem(39, armor.length > 0 ? armor[0] : null); // Boots
+
+        inventory.setItem(40, data.getOffhandItem());
+
+        for (int slot = 41; slot < 45; slot++) {
+            inventory.setItem(slot, fillerItem.clone());
+        }
+
+        viewer.openInventory(inventory);
+    }
+
+    private void openEnderChestInventory(Player viewer, OfflinePlayerData data) {
+        OfflineInventoryHolder holder = new OfflineInventoryHolder(data, true);
+        Inventory inventory = Bukkit.createInventory(holder, 27,
+            messageManager.get("inventory_view_title_ender").replace("{player}", data.getDisplayName()));
+        holder.setInventory(inventory);
+
+        ItemStack[] contents = data.getEnderChestContents();
+        for (int i = 0; i < inventory.getSize(); i++) {
+            inventory.setItem(i, i < contents.length ? contents[i] : null);
+        }
+
+        viewer.openInventory(inventory);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getInventory().getHolder() instanceof OfflineInventoryHolder holder)) {
+            return;
+        }
+
+        if (!holder.isEnderChest()) {
+            int rawSlot = event.getRawSlot();
+            int topSize = event.getView().getTopInventory().getSize();
+            if (rawSlot < topSize && rawSlot >= 41) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (!(event.getInventory().getHolder() instanceof OfflineInventoryHolder holder)) {
+            return;
+        }
+
+        if (holder.isEnderChest()) {
+            return;
+        }
+
+        int topSize = event.getView().getTopInventory().getSize();
+        for (int rawSlot : event.getRawSlots()) {
+            if (rawSlot < topSize && rawSlot >= 41) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getInventory().getHolder() instanceof OfflineInventoryHolder holder)) {
+            return;
+        }
+
+        Inventory inventory = event.getInventory();
+        OfflinePlayerData data = holder.getData();
+        UUID viewerId = ((Player) event.getPlayer()).getUniqueId();
+
+        if (holder.isEnderChest()) {
+            ItemStack[] contents = Arrays.copyOf(inventory.getContents(), inventory.getSize());
+            data.setEnderChestContents(contents);
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                boolean success = databaseManager.saveOfflineEnderChestData(data);
+                if (!success) {
+                    notifySaveFailure(viewerId, data.getDisplayName());
+                }
+            });
+        } else {
+            ItemStack[] main = new ItemStack[36];
+            for (int i = 0; i < 36; i++) {
+                main[i] = inventory.getItem(i);
+            }
+
+            ItemStack[] armor = new ItemStack[4];
+            armor[3] = inventory.getItem(36); // helmet
+            armor[2] = inventory.getItem(37); // chestplate
+            armor[1] = inventory.getItem(38); // leggings
+            armor[0] = inventory.getItem(39); // boots
+            ItemStack offhand = inventory.getItem(40);
+
+            data.setInventoryContents(main);
+            data.setArmorContents(armor);
+            data.setOffhandItem(offhand);
+
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                boolean success = databaseManager.saveOfflineInventoryData(data);
+                if (!success) {
+                    notifySaveFailure(viewerId, data.getDisplayName());
+                }
+            });
+        }
+    }
+
+    private void notifySaveFailure(UUID viewerId, String playerName) {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            Player viewer = Bukkit.getPlayer(viewerId);
+            if (viewer != null && viewer.isOnline()) {
+                viewer.sendMessage(messageManager.get("prefix") + " "
+                    + messageManager.get("inventory_view_save_failed").replace("{player}", playerName));
+            }
+        });
+    }
+
+    private ItemStack createFillerItem() {
+        ItemStack pane = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = pane.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+            pane.setItemMeta(meta);
+        }
+        return pane;
+    }
+
+    private static final class OfflineInventoryHolder implements InventoryHolder {
+        private final OfflinePlayerData data;
+        private final boolean enderChest;
+        private Inventory inventory;
+
+        private OfflineInventoryHolder(OfflinePlayerData data, boolean enderChest) {
+            this.data = data;
+            this.enderChest = enderChest;
+        }
+
+        @Override
+        public Inventory getInventory() {
+            return inventory;
+        }
+
+        private void setInventory(Inventory inventory) {
+            this.inventory = inventory;
+        }
+
+        private OfflinePlayerData getData() {
+            return data;
+        }
+
+        private boolean isEnderChest() {
+            return enderChest;
+        }
+    }
+}

--- a/src/main/java/com/example/playerdatasync/OfflinePlayerData.java
+++ b/src/main/java/com/example/playerdatasync/OfflinePlayerData.java
@@ -1,0 +1,77 @@
+package com.example.playerdatasync;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.UUID;
+
+/**
+ * Represents offline player inventory data that can be viewed or edited
+ * without the player being online.
+ */
+public class OfflinePlayerData {
+    private final UUID uuid;
+    private final String lastKnownName;
+    private ItemStack[] inventoryContents;
+    private ItemStack[] armorContents;
+    private ItemStack[] enderChestContents;
+    private ItemStack offhandItem;
+    private boolean existsInDatabase;
+
+    public OfflinePlayerData(UUID uuid, String lastKnownName) {
+        this.uuid = uuid;
+        this.lastKnownName = lastKnownName;
+        this.inventoryContents = new ItemStack[0];
+        this.armorContents = new ItemStack[0];
+        this.enderChestContents = new ItemStack[0];
+        this.offhandItem = null;
+        this.existsInDatabase = false;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public String getDisplayName() {
+        return lastKnownName != null ? lastKnownName : (uuid != null ? uuid.toString() : "unknown");
+    }
+
+    public ItemStack[] getInventoryContents() {
+        return inventoryContents != null ? inventoryContents : new ItemStack[0];
+    }
+
+    public void setInventoryContents(ItemStack[] inventoryContents) {
+        this.inventoryContents = inventoryContents != null ? inventoryContents : new ItemStack[0];
+    }
+
+    public ItemStack[] getArmorContents() {
+        return armorContents != null ? armorContents : new ItemStack[0];
+    }
+
+    public void setArmorContents(ItemStack[] armorContents) {
+        this.armorContents = armorContents != null ? armorContents : new ItemStack[0];
+    }
+
+    public ItemStack[] getEnderChestContents() {
+        return enderChestContents != null ? enderChestContents : new ItemStack[0];
+    }
+
+    public void setEnderChestContents(ItemStack[] enderChestContents) {
+        this.enderChestContents = enderChestContents != null ? enderChestContents : new ItemStack[0];
+    }
+
+    public ItemStack getOffhandItem() {
+        return offhandItem;
+    }
+
+    public void setOffhandItem(ItemStack offhandItem) {
+        this.offhandItem = offhandItem;
+    }
+
+    public boolean existsInDatabase() {
+        return existsInDatabase;
+    }
+
+    public void setExistsInDatabase(boolean existsInDatabase) {
+        this.existsInDatabase = existsInDatabase;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -124,6 +124,8 @@ integrations:
   luckperms: false      # enable LuckPerms integration
   vault: true           # enable Vault integration for economy
   placeholderapi: false # enable PlaceholderAPI support
+  invsee: true          # enable InvSee++ style inventory viewing integration
+  openinv: true         # enable OpenInv style inventory viewing integration
 
 # Message Configuration
 messages:

--- a/src/main/resources/messages_de.yml
+++ b/src/main/resources/messages_de.yml
@@ -94,6 +94,15 @@ integration_luckperms_disabled: "&eLuckPerms-Integration deaktiviert."
 integration_bungeecord_enabled: "&aBungeeCord-Modus aktiviert."
 integration_placeholderapi_enabled: "&aPlaceholderAPI-Integration aktiviert."
 
+inventory_view_usage_inventory: "&cVerwendung: /invsee <Spieler>"
+inventory_view_usage_ender: "&cVerwendung: /endersee <Spieler>"
+inventory_view_loading: "&7Lade gespeicherte Daten für &b{player}&7..."
+inventory_view_no_data: "&eKeine gespeicherten Daten für &b{player}&e gefunden. Es wird ein leeres Inventar angezeigt."
+inventory_view_open_failed: "&cGespeicherte Daten für &b{player}&c konnten nicht geladen werden."
+inventory_view_save_failed: "&cÄnderungen für &b{player}&c konnten nicht gespeichert werden. Siehe Konsole für Details."
+inventory_view_title_inventory: "&8Inventar » &b{player}"
+inventory_view_title_ender: "&8Endertruhe » &b{player}"
+
 # Editor-Integrationsnachrichten
 editor_disabled: "&cDie Editor-Integration ist nicht konfiguriert. Setze PDS_EDITOR_API_KEY oder die System-Property pds.editor.apiKey."
 editor_player_required: "&cBitte gib einen Spieler an, wenn du den Befehl von der Konsole nutzt."

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -87,12 +87,20 @@ security_encryption_enabled: "&aData encryption is enabled."
 security_encryption_disabled: "&eData encryption is disabled."
 
 # Integration Messages
+integration_placeholderapi_enabled: "&aPlaceholderAPI integration enabled."
 integration_vault_enabled: "&aVault integration enabled."
 integration_vault_disabled: "&eVault integration disabled."
 integration_luckperms_enabled: "&aLuckPerms integration enabled."
 integration_luckperms_disabled: "&eLuckPerms integration disabled."
 integration_bungeecord_enabled: "&aBungeeCord mode enabled."
-integration_placeholderapi_enabled: "&aPlaceholderAPI integration enabled."
+inventory_view_usage_inventory: "&cUsage: /invsee <player>"
+inventory_view_usage_ender: "&cUsage: /endersee <player>"
+inventory_view_loading: "&7Loading stored data for &b{player}&7..."
+inventory_view_no_data: "&eNo stored data found for &b{player}&e. Showing empty inventory."
+inventory_view_open_failed: "&cUnable to load stored data for &b{player}&c."
+inventory_view_save_failed: "&cFailed to save changes for &b{player}&c. Check console for details."
+inventory_view_title_inventory: "&8Inventory » &b{player}"
+inventory_view_title_ender: "&8Ender Chest » &b{player}"
 
 # Editor Integration Messages
 editor_disabled: "&cThe web editor integration is not configured. Set PDS_EDITOR_API_KEY or the system property pds.editor.apiKey."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -61,6 +61,8 @@ permissions:
       playerdatasync.admin.editor: true
       playerdatasync.admin.reload: true
       playerdatasync.admin.save: true
+      playerdatasync.integration.invsee: true
+      playerdatasync.integration.enderchest: true
       playerdatasync.backup: true
       playerdatasync.import: true
       playerdatasync.export: true
@@ -187,3 +189,9 @@ permissions:
   playerdatasync.integration.luckperms:
     description: Allow LuckPerms integration
     default: false
+  playerdatasync.integration.invsee:
+    description: Allows viewing and editing stored player inventories through InvSee/OpenInv integration
+    default: op
+  playerdatasync.integration.enderchest:
+    description: Allows viewing and editing stored player ender chests through InvSee/OpenInv integration
+    default: op


### PR DESCRIPTION
## Summary
- add an InventoryViewerIntegrationManager to route InvSee/OpenInv style commands through PlayerDataSync storage and save viewer edits
- expose OfflinePlayerData utilities and new DatabaseManager helpers to load/update inventories and ender chests when players are offline
- extend configuration, permissions, and localized messages for enabling the integration and informing admins

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returned 403 during plugin resolution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc884c59c832eb19e0a4c9954af80)