### PR TITLE
Fix duplicated JAR name in Maven build output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
     <artifactId>PlayerDataSync</artifactId>
-    <version>PlayerDataSync-26.2-RELEASE</version>
+    <version>26.2-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>PlayerDataSync</name>


### PR DESCRIPTION
### Motivation
- The project `version` in the root `pom.xml` included the artifact name (`PlayerDataSync-26.2-RELEASE`), which produced a packaged filename of `<artifactId>-<version>.jar` resulting in `PlayerDataSync-PlayerDataSync-26.2-RELEASE.jar` instead of the desired `PlayerDataSync-26.2-RELEASE.jar`.

### Description
- Updated the root `pom.xml` to set `<version>` to `26.2-RELEASE` instead of `PlayerDataSync-26.2-RELEASE`, so the final artifact name becomes `PlayerDataSync-26.2-RELEASE.jar`.

### Testing
- Ran `mvn -DskipTests package` which now prints the project version as `26.2-RELEASE` during build startup, confirming the version change; the build could not complete in this environment due to remote Maven repo `403 Forbidden` errors when downloading plugins, so packaging could not be fully verified locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699619745d3c832eb1a2d8e4f9a832df)